### PR TITLE
chore: 本番環境でスキーマー変更時にmigrateができるように変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,9 @@ FROM node:22-slim AS runner
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     sqlite3 \
+    sqlite3-tools \
     ca-certificates \
-    gettext-base \
+    gzip \
     && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /app/db && \
     chown -R node:node /app

--- a/run.sh
+++ b/run.sh
@@ -27,6 +27,23 @@ fi
 # Before starting the app, ensure WAL mode is disabled for Prisma compatibility
 sqlite3 /app/db/prod.db "PRAGMA journal_mode=DELETE;"
 
+# Check for migration mode
+if [ "${RUN_MIGRATIONS}" = "true" ]; then
+
+    echo "Migration mode detected. Running migrations..."
+    
+    # WAL mode must be disabled for Prisma compatibility
+    sqlite3 /app/db/prod.db "PRAGMA journal_mode=DELETE;"
+    
+    # Run Prisma migrations
+    DATABASE_URL="file:/app/db/prod.db" npx prisma migrate deploy
+    
+    echo "Migrations completed successfully"
+else
+    # WAL mode must be disabled for Prisma compatibility
+    sqlite3 /app/db/prod.db "PRAGMA journal_mode=DELETE;"
+fi
+
 # Start Litestream replication with the app as the subprocess
 exec litestream replicate \
     -config /app/litestream.yml \


### PR DESCRIPTION
close #62 

`RUN_MIGRATIONS`を環境変数に渡すことで本番環境でmigrateができるようにした。

テスト環境で有効なことを確認済み。

## Summary

This pull request includes important updates to the `Dockerfile` and `run.sh` to enhance the application's setup and migration process. The key changes are:

### Dockerfile updates:

* Added `sqlite3-tools` and `gzip` to the list of installed packages for better database management and compression capabilities. (`[DockerfileR71-R73](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R71-R73)`)

### run.sh updates:

* Added a check for a migration mode environment variable (`RUN_MIGRATIONS`) to conditionally run Prisma migrations, ensuring that migrations are performed only when needed. (`[run.shR30-R46](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR30-R46)`)
* Included appropriate messages to indicate the start and completion of the migration process for better logging and debugging. (`[run.shR30-R46](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR30-R46)`)