### PR TITLE
”すべて削除”ボタンを画面から削除

### DIFF
--- a/app/routes/kitchen.tsx
+++ b/app/routes/kitchen.tsx
@@ -30,7 +30,7 @@ export default function Kitchen() {
 
   return (
     <>
-      <Button
+      {/* <Button
         colorScheme="red"
         onClick={onOpen}
         position="relative"
@@ -39,7 +39,7 @@ export default function Kitchen() {
         mb="4"
       >
         すべて削除
-      </Button>
+      </Button> */}
       <Wrap>
         {orders.map((order) => {
           const createTime = new Date(order.createTime).toLocaleString(
@@ -75,7 +75,7 @@ export default function Kitchen() {
         })}
       </Wrap>
 
-      <Modal isOpen={isOpen} onClose={onClose} motionPreset="slideInBottom">
+      {/* <Modal isOpen={isOpen} onClose={onClose} motionPreset="slideInBottom">
         <ModalOverlay />
         <ModalContent pb={2}>
           <ModalBody mx={4}>
@@ -92,7 +92,7 @@ export default function Kitchen() {
             </Button>
           </ModalBody>
         </ModalContent>
-      </Modal>
+      </Modal> */}
     </>
   )
 }


### PR DESCRIPTION
厨房画面にあった”すべて削除”ボタンを間違って押してしまうことがないようにコメントアウトしました。