### PR TITLE
perf: 注文番号入力欄が重い問題を修正

### DIFF
--- a/app/routes/reception.tsx
+++ b/app/routes/reception.tsx
@@ -56,7 +56,7 @@ export default function Reception() {
   const actionData = useActionData<ActionData>()
   const { showMessage } = useMessage()
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const [tableNumber, setTableNumber] = useState("")
+  const tableNumberRef = useRef<HTMLInputElement>(null)
 
   // const fetcher = useFetcher();
 
@@ -81,7 +81,7 @@ export default function Reception() {
       if (orderMemoRef.current) orderMemoRef.current.value = ""
       showMessage({ title: "注文しました", status: "success" })
       onClose()
-      setTableNumber("")
+      if (tableNumberRef.current) tableNumberRef.current.value = ""
     } else if (actionData?.success === false) {
       const errorMessage = actionData.error || "エラーが発生しました"
       showMessage({ title: errorMessage, status: "error" })
@@ -143,10 +143,6 @@ export default function Reception() {
     setTotal(totalPrice)
     // setDecision(true)
     onOpen()
-  }
-
-  const tableNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTableNumber(e.target.value)
   }
 
   return (
@@ -223,8 +219,7 @@ export default function Reception() {
                       <Input
                         type="number"
                         name="table_number"
-                        onChange={tableNumberChange}
-                        value={tableNumber}
+                        ref={tableNumberRef}
                         bg="gray.300"
                       />
                     </Text>


### PR DESCRIPTION
This pull request makes several changes to the `Reception` component in the `app/routes/reception.tsx` file to refactor the handling of the `tableNumber` state. The most important changes include replacing the state with a reference and removing the associated state management code.

Refactoring state management:

* Replaced the `tableNumber` state with a `useRef` hook to manage the table number input (`tableNumberRef`).
* Updated the table number input field to use the `tableNumberRef` reference instead of state.
* Removed the `tableNumberChange` function and the `setTableNumber` calls since the state is no longer used. [[1]](diffhunk://#diff-6e019bf6c3a4fbc3743aee4e5cb2fd1f1a119d85105eb9a2d7d9a8d2a15e271bL148-L151) [[2]](diffhunk://#diff-6e019bf6c3a4fbc3743aee4e5cb2fd1f1a119d85105eb9a2d7d9a8d2a15e271bL84-R84)