### PR TITLE
マウスホイールによる問題を解決

### DIFF
--- a/app/routes/reception.tsx
+++ b/app/routes/reception.tsx
@@ -226,6 +226,15 @@ export default function Reception() {
                         onChange={tableNumberChange}
                         value={tableNumber}
                         bg="gray.300"
+                        onFocus={(e) =>
+                          e.target.addEventListener(
+                            "wheel",
+                            (e) => {
+                              e.preventDefault()
+                            },
+                            { passive: false },
+                          )
+                        }
                       />
                     </Text>
                     <Text mt={4}>注文メモ：</Text>


### PR DESCRIPTION
注文画面でテーブル番号をマウスホイールで動かすことができたので、マウスホイールでの入力を無効にした。